### PR TITLE
Remove yarp/os/LockGuard.h include as useless

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -8,7 +8,6 @@
 #include <cmath>
 
 #include <yarp/os/Network.h>
-#include <yarp/os/LockGuard.h>
 #include <yarp/os/LogStream.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/ResourceFinder.h>


### PR DESCRIPTION
As per the title.

Fix #3 